### PR TITLE
User defined cost objective in OMPL bug - Fixed.

### DIFF
--- a/src/ompl/base/src/ProblemDefinition.cpp
+++ b/src/ompl/base/src/ProblemDefinition.cpp
@@ -425,6 +425,8 @@ void ompl::base::ProblemDefinition::addSolutionPath(const PathPtr &path, bool ap
                                                     const std::string &plannerName) const
 {
     PlannerSolution sol(path);
+    Cost sol_cost {path->cost(optimizationObjective_)};
+    sol.setOptimized(optimizationObjective_, sol_cost, false);
     if (approximate)
         sol.setApproximate(difference);
     sol.setPlannerName(plannerName);


### PR DESCRIPTION
this PR adds 2 lines that make sure that the costObjective from the problem definition is passed to solutions added to solutionSet. For us, this means that solutions generated by thunder will carry information about the costObjective we pass to thunder in multibody_ompl_interface and therefore will allow ompl to sort solutions correctly. This is better than sorting in dig since it is propagated to all other cost comparisons we rely on OMPL to make: saving the lowest cost path to SPARS, using lowest cost paths in algorithms like RRTstar and CForest, etc...