### PR TITLE
L2 (instead of L1) distance in OMPL's compound state space.

### DIFF
--- a/src/ompl/base/src/StateSpace.cpp
+++ b/src/ompl/base/src/StateSpace.cpp
@@ -1071,8 +1071,8 @@ double ompl::base::CompoundStateSpace::distance(const State *state1, const State
     const auto *cstate2 = static_cast<const CompoundState *>(state2);
     double dist = 0.0;
     for (unsigned int i = 0; i < componentCount_; ++i)
-        dist += weights_[i] * components_[i]->distance(cstate1->components[i], cstate2->components[i]);
-    return dist;
+        dist += weights_[i] * std::pow(components_[i]->distance(cstate1->components[i], cstate2->components[i]),2);
+    return std::sqrt(dist);
 }
 
 void ompl::base::CompoundStateSpace::setLongestValidSegmentFraction(double segmentFraction)


### PR DESCRIPTION
This is the L2 distance on branch of its own, to be merged with main.

Taking L2 distance instead of L1, and then optimizing based on path length, means that we favor "diagonal" paths in joint space as opposed to rectangular paths. This, on robot, means that we make it more likely for the robot to move its joints simultaneously, instead of moving them one at a time, to get from a state to another.