### PR TITLE
Save returned plans, even if from recall

### DIFF
--- a/src/ompl/tools/thunder/src/Thunder.cpp
+++ b/src/ompl/tools/thunder/src/Thunder.cpp
@@ -301,7 +301,7 @@ ompl::base::PlannerStatus ompl::tools::Thunder::solve(const base::PlannerTermina
                 log.is_saved = "less_2_states";
                 log.too_short = true;
             }
-            else if (false)  // always add when from recall
+            else if (true)  // always add when from recall
             {
                 OMPL_INFORM("Adding path to database because SPARS will decide for us if we should keep the nodes");
 


### PR DESCRIPTION
Always save plans even if they are from recall. This does not hurt and could actually beneficial. There is no reason to not to at least try to save the start goal states.