### PR TITLE
parameter to control number of threads used in CForest

### DIFF
--- a/src/ompl/tools/thunder/Thunder.h
+++ b/src/ompl/tools/thunder/Thunder.h
@@ -110,6 +110,7 @@ namespace ompl
             double DenseD_{};
             double SparseD_{};
             size_t n_threads_{0};
+            size_t cforest_n_threads_{0};
 
         public:
             /** \brief Display debug data about potential available solutions */
@@ -197,6 +198,16 @@ namespace ompl
             /** \brief Get the number of threads used for planning. */
             size_t getNumThreads() const {
               return n_threads_;
+            }
+            
+            /** \brief Set the number of threads to use for planning. */
+            void setCforestNumThreads(const size_t cforest_n_threads) {
+              cforest_n_threads_ = cforest_n_threads;
+            }
+
+            /** \brief Get the number of threads used for planning. */
+            size_t getCforestNumThreads() const {
+              return cforest_n_threads_;
             }
 
             /** \brief This method will create the necessary classes

--- a/src/ompl/tools/thunder/Thunder.h
+++ b/src/ompl/tools/thunder/Thunder.h
@@ -109,7 +109,7 @@ namespace ompl
             double stretch_factor_{};
             double DenseD_{};
             double SparseD_{};
-            size_t n_threads_{0};
+            size_t n_parallel_plans_{0};
             size_t cforest_n_threads_{0};
 
         public:
@@ -191,15 +191,15 @@ namespace ompl
             }
 
             /** \brief Set the number of threads to use for planning. */
-            void setNumThreads(const size_t n_threads) {
-              n_threads_ = n_threads;
+            void setNumParallelPlans(const size_t n_parallel_plans) {
+              n_parallel_plans_ = n_parallel_plans;
             }
 
             /** \brief Get the number of threads used for planning. */
-            size_t getNumThreads() const {
-              return n_threads_;
+            size_t getNumParallelPlans() const {
+              return n_parallel_plans_;
             }
-            
+
             /** \brief Set the number of threads to use for planning. */
             void setCforestNumThreads(const size_t cforest_n_threads) {
               cforest_n_threads_ = cforest_n_threads;

--- a/src/ompl/tools/thunder/src/Thunder.cpp
+++ b/src/ompl/tools/thunder/src/Thunder.cpp
@@ -109,7 +109,9 @@ void ompl::tools::Thunder::setup()
                 }
                 else if (planner_type_ == thunderPlanner::PLANNER_CFOREST)
                 {
-                    planner = std::make_shared<ompl::geometric::CForest>(si_);
+                    auto cforest_planner {std::make_shared<ompl::geometric::CForest>(si_)};
+                    cforest_planner->setNumThreads(cforest_n_threads_);
+                    planner = cforest_planner;
                 }
                 else
                 {

--- a/src/ompl/tools/thunder/src/Thunder.cpp
+++ b/src/ompl/tools/thunder/src/Thunder.cpp
@@ -85,8 +85,8 @@ void ompl::tools::Thunder::setup()
         // Setup planning from scratch planner
         OMPL_INFORM("Initializing planners");
         // set number of threads if not already set
-        if(n_threads_ == 0) {
-          n_threads_ = std::max(std::thread::hardware_concurrency(), 2u) - 1;
+        if(n_parallel_plans_ == 0) {
+          n_parallel_plans_ = std::max(std::thread::hardware_concurrency(), 2u) - 1;
         }
         // set the size of the planner vector
         planner_vec_.clear();
@@ -94,7 +94,7 @@ void ompl::tools::Thunder::setup()
           std::vector<base::PlannerPtr> planner_vec {1};
           planner_vec_ = planner_vec;
         } else {
-          std::vector<base::PlannerPtr> planner_vec (n_threads_);
+          std::vector<base::PlannerPtr> planner_vec (n_parallel_plans_);
           planner_vec_ = planner_vec;
         }
         // set up planner ptr vector based on planner type


### PR DESCRIPTION
128 threads is an overkill in offline planning since we don't have working PTCs. Until then allowing control of number of threads is a reasonable alternative that reduces offline planning times