### PR TITLE
fix: add interface edges for shorter paths with less states.

### DIFF
--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -988,7 +988,7 @@ bool ompl::geometric::SPARSdb::addStateToRoadmap(const base::PlannerTerminationC
         {
             if (verbose_)
                 OMPL_INFORM(" --- checkAddInterface() Does this node's neighbor's need it to better connect them? ");
-            if (denseRoadmap_ || !checkAddInterface(qNew, graphNeighborhood, visibleNeighborhood)) // @TODO - Ramy: I think with the new changes this becomes unnecessary. Test without it and see.
+            if (!checkAddInterface(qNew, graphNeighborhood, visibleNeighborhood)) // @TODO - Ramy: I think with the new changes this becomes unnecessary. Test without it and see.
             {
                 if (verbose_)
                     OMPL_INFORM(" ---- Ensure SPARS asymptotic optimality");


### PR DESCRIPTION
Weird behavior on Tequila today uncoverd an issue with recalled plans: some of them are long and have a lot of states.
After debugging the issue it turns out that we are not adding enough long edges in the roadmap. Adding interface edges will help with that, but more code fixes have to be put it and are being worked on now.
The change in this PR has been tested on dev machines and has been shown to shorten paths and lessen the number of states in a path.