### PR TITLE
add: allow scaling the distance heuristic in A-star for recalled paths with less nodes and edges

### DIFF
--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -428,6 +428,11 @@ namespace ompl
                 collisionCheckOnRecall_ = collisionCheckOnRecall;
             }
 
+            void setHeuristicScaling(const double heuristicScaling)
+            {
+                heuristicScaling_ = heuristicScaling;
+            }
+
             /** \brief Retrieve the maximum consecutive failure limit. */
             unsigned int getMaxFailures() const
             {
@@ -465,6 +470,11 @@ namespace ompl
             bool getCollisionCheckOnRecall() const
             {
                 return collisionCheckOnRecall_;
+            }
+
+            double getHeuristicScaling() const
+            {
+                return heuristicScaling_;
             }
 
             bool getGuardSpacingFactor(double pathLength, double &numGuards, double &spacingFactor);
@@ -818,6 +828,8 @@ namespace ompl
             /** \brief Used by getSimilarPaths */
             std::vector<Vertex> startVertexCandidateNeighbors_;
             std::vector<Vertex> goalVertexCandidateNeighbors_;
+
+            double heuristicScaling_ {1.0};
 
             /** \brief Option to enable debugging output */
             bool verbose_{false};

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -829,7 +829,7 @@ namespace ompl
             std::vector<Vertex> startVertexCandidateNeighbors_;
             std::vector<Vertex> goalVertexCandidateNeighbors_;
 
-            double heuristicScaling_ {1.0};
+            double heuristicScaling_ {1.2};
 
             /** \brief Option to enable debugging output */
             bool verbose_{false};

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -829,7 +829,7 @@ namespace ompl
             std::vector<Vertex> startVertexCandidateNeighbors_;
             std::vector<Vertex> goalVertexCandidateNeighbors_;
 
-            double heuristicScaling_ {1.2};
+            double heuristicScaling_ {1.0};
 
             /** \brief Option to enable debugging output */
             bool verbose_{false};

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -427,7 +427,7 @@ bool ompl::geometric::SPARSdb::constructSolution(const Vertex start, const Verte
                             start,  // start state
                             [this, goal](const Vertex v)
                             {
-                                return distanceFunction(v, goal);
+                                return heuristicScaling_ * distanceFunction(v, goal);
                             },  // the heuristic
                             // ability to disable edges (set cost to inifinity):
                             boost::weight_map(edgeWeightMap(g_, edgeCollisionStateProperty_))


### PR DESCRIPTION
https://dexai.slack.com/archives/CKP9FT41X/p1644946499836739

A small change to the heuristic gives recalled paths with less edges and nodes without hurting path quality.

This PR is linked to dig #1696