### PR TITLE
add: option to store custom cost in edges as opposed to just length

### DIFF
--- a/src/ompl/geometric/planners/experience/src/ThunderRetrieveRepair.cpp
+++ b/src/ompl/geometric/planners/experience/src/ThunderRetrieveRepair.cpp
@@ -168,7 +168,7 @@ namespace ompl
             assert(candidateSolution.getStateCount() >= 4);
 
             // Smooth the result
-            if (true || smoothingEnabled_)
+            if (smoothingEnabled_)
             {
                 OMPL_INFORM("ThunderRetrieveRepair solve: Simplifying solution (smoothing)...");
                 time::point simplifyStart = time::now();

--- a/src/ompl/geometric/planners/experience/src/ThunderRetrieveRepair.cpp
+++ b/src/ompl/geometric/planners/experience/src/ThunderRetrieveRepair.cpp
@@ -168,7 +168,7 @@ namespace ompl
             assert(candidateSolution.getStateCount() >= 4);
 
             // Smooth the result
-            if (smoothingEnabled_)
+            if (true || smoothingEnabled_)
             {
                 OMPL_INFORM("ThunderRetrieveRepair solve: Simplifying solution (smoothing)...");
                 time::point simplifyStart = time::now();

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -740,6 +740,11 @@ namespace ompl
                 return si_->distance(stateProperty_[a], stateProperty_[b]);
             }
 
+            double costFunction(const Vertex a, const Vertex b) const
+            {
+                return pdef_->getOptimizationObjective()->motionCost(stateProperty_[a], stateProperty_[b]).value();
+            }
+
             /** \brief Sampler user for generating valid samples in the state space */
             base::ValidStateSamplerPtr sampler_;
 

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -97,6 +97,12 @@ namespace ompl
                 QUALITY,
             };
 
+            enum EdgeWeightsInRoadmap
+            {
+                COST_OBJECTIVE,
+                PATH_LENGTH,
+            };
+
             ////////////////////////////////////////////////////////////////////////////////////////
             // BOOST GRAPH DETAILS
             ////////////////////////////////////////////////////////////////////////////////////////
@@ -433,9 +439,9 @@ namespace ompl
                 heuristicScaling_ = heuristicScaling;
             }
 
-            void setUseCostInRoadmap(const bool useCostInRoadmap)
+            void setEdgeWeightsInRoadmap(const EdgeWeightsInRoadmap weights)
             {
-                useCostInRoadmap_ = useCostInRoadmap;
+                edgeWeights_ = weights;
             }
 
             /** \brief Retrieve the maximum consecutive failure limit. */
@@ -482,9 +488,9 @@ namespace ompl
                 return heuristicScaling_;
             }
 
-            bool getUseCostInRoadmap() const
+            EdgeWeightsInRoadmap getEdgeWeightsInRoadmap() const
             {
-                return useCostInRoadmap_;
+                return edgeWeights_;
             }
 
             bool getGuardSpacingFactor(double pathLength, double &numGuards, double &spacingFactor);
@@ -842,6 +848,8 @@ namespace ompl
 
             /** \brief Toggles using custom cost function as edge weight in roadmap as opposed to just path length */
             bool useCostInRoadmap_ {false};
+
+            EdgeWeightsInRoadmap edgeWeights_ {PATH_LENGTH};
 
             /** \brief Used by getSimilarPaths */
             std::vector<Vertex> startVertexCandidateNeighbors_;

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -96,13 +96,6 @@ namespace ompl
                 INTERFACE,
                 QUALITY,
             };
-            
-            /** \brief Controls which edge weight function we are using */
-            enum EdgeWeightsInRoadmap
-            {
-                COST_OBJECTIVE,
-                PATH_LENGTH,
-            };
 
             ////////////////////////////////////////////////////////////////////////////////////////
             // BOOST GRAPH DETAILS
@@ -440,11 +433,6 @@ namespace ompl
                 heuristicScaling_ = heuristicScaling;
             }
 
-            void setEdgeWeightsInRoadmap(const EdgeWeightsInRoadmap edgeWeights)
-            {
-                edgeWeights_ = edgeWeights;
-            }
-
             /** \brief Retrieve the maximum consecutive failure limit. */
             unsigned int getMaxFailures() const
             {
@@ -487,11 +475,6 @@ namespace ompl
             double getHeuristicScaling() const
             {
                 return heuristicScaling_;
-            }
-
-            EdgeWeightsInRoadmap getEdgeWeightsInRoadmap() const
-            {
-                return edgeWeights_;
             }
 
             bool getGuardSpacingFactor(double pathLength, double &numGuards, double &spacingFactor);
@@ -759,7 +742,7 @@ namespace ompl
 
             double costFunction(const Vertex a, const Vertex b) const
             {
-                return pdef_->getOptimizationObjective()->motionCost(stateProperty_[a], stateProperty_[b]).value();
+                return pdef_->getOptimizationObjective() ? pdef_->getOptimizationObjective()->motionCost(stateProperty_[a], stateProperty_[b]).value() : distanceFunction(a, b);
             }
 
             /** \brief Sampler user for generating valid samples in the state space */
@@ -846,9 +829,6 @@ namespace ompl
 
             /** \brief Flag to indicate wheter or not we do collision checking for paths retrieved from the database */
             bool collisionCheckOnRecall_ {false};
-
-            /** \brief Controls which edge weight function we are using */
-            EdgeWeightsInRoadmap edgeWeights_ {PATH_LENGTH};
 
             /** \brief Used by getSimilarPaths */
             std::vector<Vertex> startVertexCandidateNeighbors_;

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -96,7 +96,8 @@ namespace ompl
                 INTERFACE,
                 QUALITY,
             };
-
+            
+            /** \brief Controls which edge weight function we are using */
             enum EdgeWeightsInRoadmap
             {
                 COST_OBJECTIVE,
@@ -439,9 +440,9 @@ namespace ompl
                 heuristicScaling_ = heuristicScaling;
             }
 
-            void setEdgeWeightsInRoadmap(const EdgeWeightsInRoadmap weights)
+            void setEdgeWeightsInRoadmap(const EdgeWeightsInRoadmap edgeWeights)
             {
-                edgeWeights_ = weights;
+                edgeWeights_ = edgeWeights;
             }
 
             /** \brief Retrieve the maximum consecutive failure limit. */
@@ -846,9 +847,7 @@ namespace ompl
             /** \brief Flag to indicate wheter or not we do collision checking for paths retrieved from the database */
             bool collisionCheckOnRecall_ {false};
 
-            /** \brief Toggles using custom cost function as edge weight in roadmap as opposed to just path length */
-            bool useCostInRoadmap_ {false};
-
+            /** \brief Controls which edge weight function we are using */
             EdgeWeightsInRoadmap edgeWeights_ {PATH_LENGTH};
 
             /** \brief Used by getSimilarPaths */

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -433,6 +433,11 @@ namespace ompl
                 heuristicScaling_ = heuristicScaling;
             }
 
+            void setUseCostInRoadmap(const bool useCostInRoadmap)
+            {
+                useCostInRoadmap_ = useCostInRoadmap;
+            }
+
             /** \brief Retrieve the maximum consecutive failure limit. */
             unsigned int getMaxFailures() const
             {
@@ -475,6 +480,11 @@ namespace ompl
             double getHeuristicScaling() const
             {
                 return heuristicScaling_;
+            }
+
+            bool getUseCostInRoadmap() const
+            {
+                return useCostInRoadmap_;
             }
 
             bool getGuardSpacingFactor(double pathLength, double &numGuards, double &spacingFactor);
@@ -829,6 +839,9 @@ namespace ompl
 
             /** \brief Flag to indicate wheter or not we do collision checking for paths retrieved from the database */
             bool collisionCheckOnRecall_ {false};
+
+            /** \brief Toggles using custom cost function as edge weight in roadmap as opposed to just path length */
+            bool useCostInRoadmap_ {false};
 
             /** \brief Used by getSimilarPaths */
             std::vector<Vertex> startVertexCandidateNeighbors_;

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -1683,11 +1683,7 @@ void ompl::geometric::SPARSdb::connectGuards(Vertex v, Vertex vp)
     Edge e = (boost::add_edge(v, vp, g_)).first;
 
     // Add associated properties to the edge
-    if (edgeWeights_ == COST_OBJECTIVE) {
-        edgeWeightProperty_[e] = costFunction(v, vp);  // TODO: use this value with astar
-    } else if (edgeWeights_ == PATH_LENGTH) {
-        edgeWeightProperty_[e] = distanceFunction(v, vp);  // TODO: use this value with astar
-    }
+    edgeWeightProperty_[e] = costFunction(v, vp);  // TODO: use this value with astar
     edgeCollisionStateProperty_[e] = NOT_CHECKED;
 
     // Add the edge to the incrementeal connected components datastructure

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -1683,7 +1683,11 @@ void ompl::geometric::SPARSdb::connectGuards(Vertex v, Vertex vp)
     Edge e = (boost::add_edge(v, vp, g_)).first;
 
     // Add associated properties to the edge
-    edgeWeightProperty_[e] = costFunction(v, vp);  // TODO: use this value with astar
+    if (useCostInRoadmap_) {
+        edgeWeightProperty_[e] = costFunction(v, vp);  // TODO: use this value with astar
+    } else {
+        edgeWeightProperty_[e] = distanceFunction(v, vp);  // TODO: use this value with astar
+    }
     edgeCollisionStateProperty_[e] = NOT_CHECKED;
 
     // Add the edge to the incrementeal connected components datastructure

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -1683,7 +1683,7 @@ void ompl::geometric::SPARSdb::connectGuards(Vertex v, Vertex vp)
     Edge e = (boost::add_edge(v, vp, g_)).first;
 
     // Add associated properties to the edge
-    edgeWeightProperty_[e] = distanceFunction(v, vp);  // TODO: use this value with astar
+    edgeWeightProperty_[e] = costFunction(v, vp);  // TODO: use this value with astar
     edgeCollisionStateProperty_[e] = NOT_CHECKED;
 
     // Add the edge to the incrementeal connected components datastructure

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -1683,9 +1683,9 @@ void ompl::geometric::SPARSdb::connectGuards(Vertex v, Vertex vp)
     Edge e = (boost::add_edge(v, vp, g_)).first;
 
     // Add associated properties to the edge
-    if (useCostInRoadmap_) {
+    if (edgeWeights_ == COST_OBJECTIVE) {
         edgeWeightProperty_[e] = costFunction(v, vp);  // TODO: use this value with astar
-    } else {
+    } else if (edgeWeights_ == PATH_LENGTH) {
         edgeWeightProperty_[e] = distanceFunction(v, vp);  // TODO: use this value with astar
     }
     edgeCollisionStateProperty_[e] = NOT_CHECKED;


### PR DESCRIPTION
The long awaited cost to roadmap addition. This seems to be working, from some evidence on my machine and some observations from Dave in TLG: we are picking longer paths with lower overall cost.
This needs a bit more evidence in my opinion, but can be merged right now since it is nicely flagged and other OMPL PRs need to go on top of it.