### PR TITLE
reduce computations for insertions + path sampling factor

### DIFF
--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -447,7 +447,7 @@ namespace ompl
             {
                 pathSamplingFactor_ = pathSamplingFactor;
             }
-            
+
             /** \brief Retrieve the maximum consecutive failure limit. */
             unsigned int getMaxFailures() const
             {
@@ -861,6 +861,7 @@ namespace ompl
 
             double heuristicScaling_ {1.0};
 
+            /** \brief optional variable. If set, will sample each segment in the path with this many nodes and attempt to insert */
             std::optional<int> pathSamplingFactor_ {std::nullopt};
 
             bool useCostInRoadmap_ {false};

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -433,9 +433,14 @@ namespace ompl
                 heuristicScaling_ = heuristicScaling;
             }
 
-            void setUseCostInRoadmap_(const bool useCostInRoadmap)
+            void setUseCostInRoadmap(const bool useCostInRoadmap)
             {
                 useCostInRoadmap_ = useCostInRoadmap;
+            }
+
+            void setPathSamplingFactor(const int pathSamplingFactor)
+            {
+                pathSamplingFactor_ = pathSamplingFactor;
             }
 
             /** \brief Retrieve the maximum consecutive failure limit. */
@@ -482,9 +487,14 @@ namespace ompl
                 return heuristicScaling_;
             }
 
-            bool getUseCostInRoadmap_() const
+            bool getUseCostInRoadmap() const
             {
                 return useCostInRoadmap_;
+            }
+
+            int getPathSamplingFactor() const
+            {
+                return pathSamplingFactor_;
             }
 
             bool getGuardSpacingFactor(double pathLength, double &numGuards, double &spacingFactor);
@@ -845,6 +855,8 @@ namespace ompl
             std::vector<Vertex> goalVertexCandidateNeighbors_;
 
             double heuristicScaling_ {1.0};
+
+            int pathSamplingFactor_ {1.0};
 
             bool useCostInRoadmap_ {false};
 

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -856,7 +856,7 @@ namespace ompl
 
             double heuristicScaling_ {1.0};
 
-            int pathSamplingFactor_ {1.0};
+            int pathSamplingFactor_ {4};
 
             bool useCostInRoadmap_ {false};
 

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -438,7 +438,7 @@ namespace ompl
                 useCostInRoadmap_ = useCostInRoadmap;
             }
 
-            void setPathSamplingFactor(const int pathSamplingFactor)
+            void setPathSamplingFactor(const std::optional<int> pathSamplingFactor)
             {
                 pathSamplingFactor_ = pathSamplingFactor;
             }
@@ -492,7 +492,7 @@ namespace ompl
                 return useCostInRoadmap_;
             }
 
-            int getPathSamplingFactor() const
+            std::optional<int> getPathSamplingFactor() const
             {
                 return pathSamplingFactor_;
             }
@@ -856,7 +856,7 @@ namespace ompl
 
             double heuristicScaling_ {1.0};
 
-            int pathSamplingFactor_ {4};
+            std::optional<int> pathSamplingFactor_ {std::nullopt};
 
             bool useCostInRoadmap_ {false};
 

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -438,11 +438,6 @@ namespace ompl
                 useCostInRoadmap_ = useCostInRoadmap;
             }
 
-            void setPathSamplingFactor(const std::optional<int> pathSamplingFactor)
-            {
-                pathSamplingFactor_ = pathSamplingFactor;
-            }
-
             void setPathSamplingFactor(const int pathSamplingFactor)
             {
                 pathSamplingFactor_ = pathSamplingFactor;

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -443,6 +443,10 @@ namespace ompl
                 pathSamplingFactor_ = pathSamplingFactor;
             }
 
+            void setPathSamplingFactor(const int pathSamplingFactor)
+            {
+                pathSamplingFactor_ = pathSamplingFactor;
+            }
             /** \brief Retrieve the maximum consecutive failure limit. */
             unsigned int getMaxFailures() const
             {

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -447,6 +447,7 @@ namespace ompl
             {
                 pathSamplingFactor_ = pathSamplingFactor;
             }
+            
             /** \brief Retrieve the maximum consecutive failure limit. */
             unsigned int getMaxFailures() const
             {

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -662,19 +662,22 @@ bool ompl::geometric::SPARSdb::addPathToRoadmap(const base::PlannerTerminationCo
                "%i",
                numGuards, solutionPath.getStateCount());
 
-    unsigned int n = 0;
-    const int n1 = solutionPath.getStateCount() - 1;
-    for (int i = 0; i < n1; ++i)
-        n += si_->getStateSpace()->validSegmentCount(solutionPath.getState(i), solutionPath.getState(i + 1));
 
-    if (denseRoadmap_) {
-        solutionPath.interpolate(pathSamplingFactor_ * solutionPath.getStateCount());
+
+    if (pathSamplingFactor_.has_value()) {
+        solutionPath.interpolate(pathSamplingFactor_.value() * solutionPath.getStateCount());
+        OMPL_DEBUG("The number of nodes to be added for this path is %i", pathSamplingFactor_.value() * solutionPath.getStateCount());
 
     } else {
+        unsigned int n = 0;
+        const int n1 = solutionPath.getStateCount() - 1;
+        for (int i = 0; i < n1; ++i) {
+            n += si_->getStateSpace()->validSegmentCount(solutionPath.getState(i), solutionPath.getState(i + 1));
+        }
         solutionPath.interpolate(n);
+        OMPL_DEBUG("The number of nodes to be added for this path is %i", n);
     }
 
-    OMPL_DEBUG("The number of nodes to be added for this path is %i", n);
 
     // Debug
     if (verbose_)

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -666,7 +666,7 @@ bool ompl::geometric::SPARSdb::addPathToRoadmap(const base::PlannerTerminationCo
 
     if (pathSamplingFactor_.has_value()) {
         solutionPath.interpolate(pathSamplingFactor_.value() * solutionPath.getStateCount());
-        OMPL_DEBUG("The number of nodes to be added for this path is %i", pathSamplingFactor_.value() * solutionPath.getStateCount());
+        OMPL_DEBUG("Number of nodes to be added for this path is %i", pathSamplingFactor_.value() * solutionPath.getStateCount());
 
     } else {
         unsigned int n = 0;
@@ -972,10 +972,11 @@ bool ompl::geometric::SPARSdb::addStateToRoadmap(const base::PlannerTerminationC
     if (denseRoadmap_) {
         //this added call to findGraphNeighbors is very inexpensive when granularity is small enough (which it is meant to be).
         findGraphNeighbors(qNew, gnbhd, vnbhd, granularity_);
-        if (vnbhd.size()) {
-            OMPL_DEBUG("not adding this state");
+        if (getNumConnectedComponents() == 1 && vnbhd.size()) {
+            OMPL_DEBUG("NOT adding this state");
             return false;
         }
+        OMPL_DEBUG("ADDing this state");
     }
 
     //@TODO - Ramy: Test if creating another nbhd to seperate recall from connectivity has positive effects.

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -662,8 +662,6 @@ bool ompl::geometric::SPARSdb::addPathToRoadmap(const base::PlannerTerminationCo
                "%i",
                numGuards, solutionPath.getStateCount());
 
-
-
     if (pathSamplingFactor_.has_value()) {
         solutionPath.interpolate(pathSamplingFactor_.value() * solutionPath.getStateCount());
     } else {
@@ -674,7 +672,6 @@ bool ompl::geometric::SPARSdb::addPathToRoadmap(const base::PlannerTerminationCo
         }
         solutionPath.interpolate(n);
     }
-
 
     // Debug
     if (verbose_)

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -666,8 +666,6 @@ bool ompl::geometric::SPARSdb::addPathToRoadmap(const base::PlannerTerminationCo
 
     if (pathSamplingFactor_.has_value()) {
         solutionPath.interpolate(pathSamplingFactor_.value() * solutionPath.getStateCount());
-        OMPL_DEBUG("Number of nodes to be added for this path is %i", pathSamplingFactor_.value() * solutionPath.getStateCount());
-
     } else {
         unsigned int n = 0;
         const int n1 = solutionPath.getStateCount() - 1;
@@ -675,7 +673,6 @@ bool ompl::geometric::SPARSdb::addPathToRoadmap(const base::PlannerTerminationCo
             n += si_->getStateSpace()->validSegmentCount(solutionPath.getState(i), solutionPath.getState(i + 1));
         }
         solutionPath.interpolate(n);
-        OMPL_DEBUG("The number of nodes to be added for this path is %i", n);
     }
 
 
@@ -973,10 +970,8 @@ bool ompl::geometric::SPARSdb::addStateToRoadmap(const base::PlannerTerminationC
         //this added call to findGraphNeighbors is very inexpensive when granularity is small enough (which it is meant to be).
         findGraphNeighbors(qNew, gnbhd, vnbhd, granularity_);
         if (getNumConnectedComponents() == 1 && vnbhd.size()) {
-            OMPL_DEBUG("NOT adding this state");
             return false;
         }
-        OMPL_DEBUG("ADDing this state");
     }
 
     //@TODO - Ramy: Test if creating another nbhd to seperate recall from connectivity has positive effects.

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -666,8 +666,8 @@ bool ompl::geometric::SPARSdb::addPathToRoadmap(const base::PlannerTerminationCo
         solutionPath.interpolate(pathSamplingFactor_.value() * solutionPath.getStateCount());
     } else {
         unsigned int n = 0;
-        const int n1 = solutionPath.getStateCount() - 1;
-        for (int i = 0; i < n1; ++i) {
+        const auto n1 {solutionPath.getStateCount() - 1};
+        for (size_t i = 0; i < n1; ++i) {
             n += si_->getStateSpace()->validSegmentCount(solutionPath.getState(i), solutionPath.getState(i + 1));
         }
         solutionPath.interpolate(n);
@@ -966,6 +966,7 @@ bool ompl::geometric::SPARSdb::addStateToRoadmap(const base::PlannerTerminationC
     if (denseRoadmap_) {
         //this added call to findGraphNeighbors is very inexpensive when granularity is small enough (which it is meant to be).
         findGraphNeighbors(qNew, gnbhd, vnbhd, granularity_);
+        // if roadmap has only one connected component when we try to add a node, skip the expensive attempt to add it as a connectivity node.
         if (getNumConnectedComponents() == 1 && vnbhd.size()) {
             return false;
         }


### PR DESCRIPTION
We attempt here to reduce the time it takes thunder to insert a path into the database. This code works perfectly and has shown good results with dat files generated using it being tested on robot and running in customer sites.
Dat file generation takes now around 30 mins or less, as opposed to multiple hours (5 or 6).