### PR TITLE
add flag to toggle if we want to try to connect CCs with node insertion

### DIFF
--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -413,6 +413,11 @@ namespace ompl
                 maxFailures_ = m;
             }
 
+            void setCheckConnectedComponents(const bool check_connected_components)
+            {
+                check_connected_components_ = check_connected_components;
+            }
+
             void setDenseRoadmap(const bool denseRoadmap)
             {
                 denseRoadmap_ = denseRoadmap;
@@ -465,6 +470,11 @@ namespace ompl
             double getStretchFactor() const
             {
                 return stretchFactor_;
+            }
+
+            bool getCheckConnectedComponents() const
+            {
+                return check_connected_components_;
             }
 
             bool getDenseRoadmap() const
@@ -834,6 +844,9 @@ namespace ompl
 
             /** \brief A counter for the number of iterations of the algorithm */
             long unsigned int iterations_{0ul};
+
+            /** \brief Check number of connected components on node insertion. When true, we try to insert a node if it connects connected components in the roadmap together */
+            bool check_connected_components_ {true};
 
             /** \brief Maximum visibility range for nodes in the graph */
             double sparseDelta_{0.};

--- a/src/ompl/tools/thunder/SPARSdb.h
+++ b/src/ompl/tools/thunder/SPARSdb.h
@@ -845,7 +845,7 @@ namespace ompl
             /** \brief A counter for the number of iterations of the algorithm */
             long unsigned int iterations_{0ul};
 
-            /** \brief Check number of connected components on node insertion. When true, we try to insert a node if it connects connected components in the roadmap together */
+            /** \brief When true, we insert a node if it decreases the number of connected components (results in the connection of otherwise disconnected subgraphs).  Warning: setting this true will make insertion computationally more expensive as it checks the number of connected components */
             bool check_connected_components_ {true};
 
             /** \brief Maximum visibility range for nodes in the graph */

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -967,8 +967,8 @@ bool ompl::geometric::SPARSdb::addStateToRoadmap(const base::PlannerTerminationC
         //this added call to findGraphNeighbors is very inexpensive when granularity is small enough (which it is meant to be).
         findGraphNeighbors(qNew, gnbhd, vnbhd, granularity_);
         // if roadmap has only one connected component when we try to add a node, skip the expensive attempt to add it as a connectivity node.
-        const bool check_node_cc {check_connected_components_ && getNumConnectedComponents() > 1};
-        if (!check_node_cc && vnbhd.size()) {
+        const bool check_if_node_is_connecting {check_connected_components_ && getNumConnectedComponents() > 1};
+        if (!check_if_node_is_connecting && vnbhd.size()) {
             OMPL_DEBUG("NOT adding state!");
             return false;
         }

--- a/src/ompl/tools/thunder/src/SPARSdb.cpp
+++ b/src/ompl/tools/thunder/src/SPARSdb.cpp
@@ -967,7 +967,8 @@ bool ompl::geometric::SPARSdb::addStateToRoadmap(const base::PlannerTerminationC
         //this added call to findGraphNeighbors is very inexpensive when granularity is small enough (which it is meant to be).
         findGraphNeighbors(qNew, gnbhd, vnbhd, granularity_);
         // if roadmap has only one connected component when we try to add a node, skip the expensive attempt to add it as a connectivity node.
-        if (getNumConnectedComponents() == 1 && vnbhd.size()) {
+        const bool check_node_cc {check_connected_components_ && getNumConnectedComponents() > 1};
+        if (!check_node_cc && vnbhd.size()) {
             OMPL_DEBUG("NOT adding state!");
             return false;
         }


### PR DESCRIPTION
We add a parameter that toggles whether or not we try to add a node only because it might decrease the number of connected components in the roadmap.